### PR TITLE
Fix syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and add the following:
 
 ```erlang
 {plugins, [
-    {rebar_gleam, {git, "https://github.com/gleam-lang/rebar_gleam"}},
+    {rebar_gleam, {git, "https://github.com/gleam-lang/rebar_gleam"}}
 ]}.
 ```
 


### PR DESCRIPTION
Just installed gleam. I noticed this syntax error in the readme. The comma is only necessary if there are other lines in that list and this is not the last line.